### PR TITLE
add script to create static credentials in kubeconfigs

### DIFF
--- a/kubeconfig-serviceaccounts.sh
+++ b/kubeconfig-serviceaccounts.sh
@@ -57,6 +57,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: $accountname
+  namespace: default
 YAML
 
   # give admin permissions


### PR DESCRIPTION
Kubermatic uses the kubeconfig and the credentials in it to communicate with the seed clusters. If those credentials are dynamically generated and/or shortlived tokens (like for EKS or GKE clusters), the installation might succeed, but Kubermatic will fail shortly after.

This script can be used by customers to create a static service account in each cluster and then use their tokens to authenticate, providing long-lived credentials for Kubermatic.