### PR TITLE
allow to re-use an existing values.yaml with customizations

### DIFF
--- a/pkg/command/install.go
+++ b/pkg/command/install.go
@@ -30,7 +30,7 @@ func InstallCommand(logger *logrus.Logger) cli.Command {
 			},
 			cli.StringFlag{
 				Name:   "values",
-				Usage:  "Full path to where the Helm values.yaml should be written to (will never be deleted, regardless of --keep-files)",
+				Usage:  "Full path to where the Helm values.yaml should read from / be written to",
 				EnvVar: "KUBERMATIC_VALUES_YAML",
 			},
 			cli.IntFlag{

--- a/pkg/helm/values.go
+++ b/pkg/helm/values.go
@@ -38,20 +38,20 @@ type Values struct {
 	baseURL string
 }
 
-func LoadValuesFromFile(filename string) (Values, error) {
+func LoadValuesFromFile(filename string) (*Values, error) {
 	content, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return Values{}, fmt.Errorf("failed to read %s: %v", filename, err)
+		return nil, fmt.Errorf("failed to read %s: %v", filename, err)
 	}
 
 	parsed := make(map[string]interface{})
 
 	err = yaml.Unmarshal(content, &parsed)
 	if err != nil {
-		return Values{}, fmt.Errorf("failed to parse %s as YAML: %v", filename, err)
+		return nil, fmt.Errorf("failed to parse %s as YAML: %v", filename, err)
 	}
 
-	return Values{
+	return &Values{
 		data:    parsed,
 		domains: make(map[string]string),
 		secrets: make(map[string]string),

--- a/pkg/installer/result.go
+++ b/pkg/installer/result.go
@@ -9,7 +9,7 @@ import (
 // that get created during the installation, like generated
 // Helm values, passwords, IP addresses etc.
 type Result struct {
-	HelmValues        helm.Values
+	HelmValues        *helm.Values
 	NginxIngresses    []kubernetes.Ingress
 	NodeportIngresses []kubernetes.Ingress
 }


### PR DESCRIPTION
To use the installer for more than the initial installation, we must anticipate that customers want to make changes to their values.yaml (because the manifest does not and cannot contain each and every possible configuration). As a reminder, we opted to allow to give customers access to the values.yaml

* to enable them to use a typical Helm-based workflow after the initial setup and
* to not have to duplicate all options in the manifest and keep them in-sync with the charts

To enable customers to use their values.yaml instead of what we would generate from the manifest, the `--values` switch was repurposed to allow specifying an _existing_ file. If the file is given, we will not overwrite it, but load it instead of loading the default `values.example.yaml`.

The user still has to specify the manifest at all times because only it contains the kubeconfig and without a kubeconfig nothing works.