### PR TITLE
improve Makefiles for use in Prow

### DIFF
--- a/install-wizard/Dockerfile
+++ b/install-wizard/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:18.04
 
+ENV NODEJS_VERSION=v10.15.2
+
+# when building this image, customize it to the host's user
 ARG USER_ID=1000
 ARG GROUP_ID=1000
 
@@ -17,14 +20,14 @@ RUN apt-get install -y bash vim wget xz-utils make python git google-chrome-stab
 RUN apt-get build-dep -y nodejs
 
 # just get a recent nodejs with npm included
-RUN wget -O /opt/n.tar.xz https://nodejs.org/dist/v10.4.1/node-v10.4.1-linux-x64.tar.xz
+RUN wget -O /opt/n.tar.xz https://nodejs.org/dist/$NODEJS_VERSION/node-$NODEJS_VERSION-linux-x64.tar.xz
 RUN tar x -C /opt -f /opt/n.tar.xz
 RUN for x in /opt/node*/bin/*; do ln -sfn $x /usr/local/bin ; done
 
-# polish environment
+# do not run commands as root
 RUN groupadd -g ${GROUP_ID} node && \
     useradd -c 'Node User' -m -d /home/node -s /bin/bash -u ${USER_ID} -g ${GROUP_ID} node
 USER node
-ENV HOME /home/node
+ENV HOME=/home/node
 ENV PATH="${PATH}:/home/node/app/node_modules/.bin"
 WORKDIR /home/node

--- a/install-wizard/Makefile
+++ b/install-wizard/Makefile
@@ -1,27 +1,26 @@
-.PHONY: npminstall
-npminstall: docker
-	docker run --rm -v $(realpath .):/home/node/app -w /home/node/app install-wizard npm install
+DOCKER_IMAGE=kubermatic/install-wizard
+CMD?=bash
 
-.PHONY: npmstart
-npmstart: docker
-	docker run --rm -it -v $(realpath .):/home/node/app -w /home/node/app --net host install-wizard npm start
+install:
+	npm install
 
-.PHONY: shell
-shell: docker
-	docker run --rm -it -v $(realpath .):/home/node/app -w /home/node/app --net host install-wizard
+start:
+	./node_modules/.bin/ng serve
 
-.PHONY: shell
-test-headless: docker
-	docker run --rm -it -v $(realpath .):/home/node/app -w /home/node/app install-wizard npm run test-headless
+test-headless:
+	./node_modules/.bin/ng test --watch=false --browsers=ChromeInDocker
 
-.PHONY: prod
-prod: docker
-	docker run --rm -v $(realpath .):/home/node/app -w /home/node/app install-wizard ng build --prod --aot --build-optimizer --optimization
+build:
+	./node_modules/.bin/ng build --prod --aot --build-optimizer --optimization
 
-.PHONY: lint
-lint: docker
-	docker run --rm -v $(realpath .):/home/node/app -w /home/node/app install-wizard tslint -c tslint.json -p src/tslint.json
+lint:
+	./node_modules/.bin/tslint -c tslint.json -p src/tslint.json
 
-.PHONY: docker
+# Helpers for devs not wanting to have a full webstack
+# installed on their machines.
+
 docker:
-	docker build --build-arg "USER_ID=$$(id -u)" --build-arg "GROUP_ID=$$(id -g)" -t install-wizard .
+	docker build --build-arg "USER_ID=$$(id -u)" --build-arg "GROUP_ID=$$(id -g)" -t $(DOCKER_IMAGE) .
+
+shell: docker
+	docker run --rm -it -v $(realpath .):/home/node/app -w /home/node/app -p 4200:4200 $(DOCKER_IMAGE) $(CMD)

--- a/install-wizard/package.json
+++ b/install-wizard/package.json
@@ -1,15 +1,6 @@
 {
   "name": "install-wizard",
   "version": "0.0.0",
-  "scripts": {
-    "ng": "ng",
-    "start": "ng serve",
-    "build": "ng build",
-    "test": "ng test",
-    "test-headless": "ng test --watch=false --browsers=ChromeInDocker",
-    "lint": "ng lint",
-    "e2e": "ng e2e"
-  },
   "private": true,
   "dependencies": {
     "@angular/animations": "^6.1.10",


### PR DESCRIPTION
In order to have fewer dependencies on Prow, we should prepare our Makefiles to include most of the required build logic without sacrifycing the ability to use them in a Docker container for local development.

This PR primarily changes the install-wizard Makefile to not start a dedicated container for tasks like linting, running or testing. Instead, these tasks can now be run either directly on the host *or* the developer can create a container and then run `make` inside them if they do not want npm/node on their system. To make this script friendly, you can override the default shell with a `CMD` environment, so that `CMD="make lint" make shell` will start a container and then run `make lint` inside there.

The main Makefile now uses feature detection to detect npm (as a signal for an existing webstack) and automatically switches between host-based or Docker-based build workflows for the assets.