### PR TITLE
Support cert-manager DNS01 validation

### DIFF
--- a/charts/certs/templates/dns-secret.yaml
+++ b/charts/certs/templates/dns-secret.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.certificates.dnsValidation.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: letsencrypt-prod-dns
+type: Opaque
+data:
+  secret-access-key: {{ .Values.certificates.dnsValidation.route53.secretAccessKey | b64enc | quote }}
+{{- end }}

--- a/charts/certs/templates/issuer.yaml
+++ b/charts/certs/templates/issuer.yaml
@@ -23,6 +23,17 @@ spec:
     # Configure the challenge solvers.
     solvers:
     - selector: {} # empty selector matches every certificate
+      {{- if .Values.certificates.dnsValidation.enabled }}
+      dns01:
+        route53:
+          region: {{ .Values.certificates.dnsValidation.route53.region | quote }}
+          accessKeyID: {{ .Values.certificates.dnsValidation.route53.accessKeyID | quote }}
+          secretAccessKeySecretRef:
+            name: letsencrypt-prod-dns
+            key: secret-access-key
+      {{- else }}
       http01:
         ingress:
           class: nginx
+      {{- end }}
+

--- a/charts/certs/values.yaml
+++ b/charts/certs/values.yaml
@@ -7,3 +7,11 @@ certificates:
   - "kibana.kubermatic.example.com"
   issuer:
     email: dev@loodse.com
+
+  dnsValidation:
+    enabled: false
+    route53:
+      region: ""
+      accessKeyID: ""
+      secretAccessKey: ""
+


### PR DESCRIPTION
In sitatuations where endpoints are not public one can still use cert-manager with DNS validation to get Let's Encrypt certificates.