### PR TITLE
Logrotate removal

### DIFF
--- a/charts/kubermatic/static/master/kubernetes-addons.yaml
+++ b/charts/kubermatic/static/master/kubernetes-addons.yaml
@@ -59,9 +59,3 @@ items:
     name: pod-security-policy
     labels:
       addons.kubermatic.io/ensure: true
-- apiVersion: kubermatic.k8s.io/v1
-  kind: Addon
-  metadata:
-    name: logrotate
-    labels:
-      addons.kubermatic.io/ensure: true

--- a/charts/kubermatic/static/master/openshift-addons.yaml
+++ b/charts/kubermatic/static/master/openshift-addons.yaml
@@ -14,10 +14,6 @@ items:
 - apiVersion: kubermatic.k8s.io/v1
   kind: Addon
   metadata:
-    name: logrotate
-- apiVersion: kubermatic.k8s.io/v1
-  kind: Addon
-  metadata:
     name: network
   spec:
     requiredResourceTypes:


### PR DESCRIPTION
The logrotate addon has been removed by Kubermatic by [this](https://github.com/kubermatic/kubermatic/pull/7158) PR.
This PR updates the charts accordingly.